### PR TITLE
Feature/update lazy loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ This environment will include all additional dependencies mentioned above.
 Alternatively, you can install the (locked) development dependencies using:
 
 ```bash
-pip install requirements/lock/dev.txt
+uv export --group dev > requirements-dev.txt
+uv pip install -r requirements/lock/dev.txt
 ```
 
 It is not recommended to install the development dependencies with `conda`.

--- a/changelog.d/20250929_134754_wpk_update_lazy_loader.md
+++ b/changelog.d/20250929_134754_wpk_update_lazy_loader.md
@@ -1,0 +1,44 @@
+<!-- markdownlint-disable MD041 -->
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Using top level `__init__.pyi` with `lazy_loader`. This prevents having to
+  define separate imports in `TYPE_CHECKING` block for type checking and during
+  execution.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/thermoextrap/__init__.py
+++ b/src/thermoextrap/__init__.py
@@ -3,99 +3,13 @@
 
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _version
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from . import (
-        beta,
-        data,
-        idealgas,
-        lnpi,
-        models,
-        volume,
-        volume_idealgas,
-    )
-    from .core.xrutils import xrwrap_alpha, xrwrap_uv, xrwrap_xv
-    from .data import (
-        DataCentralMoments,
-        DataCentralMomentsVals,
-        factory_data_values,
-    )
+# To change top level imports edit __init__.pyi
+import lazy_loader as _lazy  # pyright: ignore[reportMissingTypeStubs]
 
-    # expose some data/models
-    from .models import (
-        Derivatives,
-        ExtrapModel,
-        ExtrapWeightedModel,
-        InterpModel,
-        InterpModelPiecewise,
-        MBARModel,
-        PerturbModel,
-        StateCollection,
-    )
-else:
-    import lazy_loader as lazy
-
-    __getattr__, __dir__, _ = lazy.attach(
-        __name__,
-        submodules=[
-            "beta",
-            "data",
-            "idealgas",
-            "lnpi",
-            "models",
-            "random",
-            "volume",
-            "volume_idealgas",
-        ],
-        submod_attrs={
-            "data": [
-                "DataCentralMoments",
-                "DataCentralMomentsVals",
-                "factory_data_values",
-            ],
-            "models": [
-                "Derivatives",
-                "ExtrapModel",
-                "ExtrapWeightedModel",
-                "InterpModel",
-                "InterpModelPiecewise",
-                "MBARModel",
-                "PerturbModel",
-                "StateCollection",
-            ],
-            "core.xrutils": ["xrwrap_alpha", "xrwrap_uv", "xrwrap_xv"],
-        },
-    )
-
+__getattr__, __dir__, __all__ = _lazy.attach_stub(__name__, __file__)  # pyright: ignore[reportUnknownVariableType]
 
 try:
     __version__ = _version("thermoextrap")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "999"
-
-
-__all__ = [
-    "DataCentralMoments",
-    "DataCentralMomentsVals",
-    "Derivatives",
-    "ExtrapModel",
-    "ExtrapWeightedModel",
-    "InterpModel",
-    "InterpModelPiecewise",
-    "MBARModel",
-    "PerturbModel",
-    "StateCollection",
-    "__version__",
-    "beta",
-    "data",
-    "factory_data_values",
-    "idealgas",
-    "lnpi",
-    "models",
-    "volume",
-    "volume_idealgas",
-    "xrwrap_alpha",
-    "xrwrap_uv",
-    "xrwrap_xv",
-]

--- a/src/thermoextrap/__init__.pyi
+++ b/src/thermoextrap/__init__.pyi
@@ -1,0 +1,54 @@
+from . import (
+    beta,
+    data,
+    idealgas,
+    lnpi,
+    models,
+    volume,
+    volume_idealgas,
+)
+from .core.xrutils import xrwrap_alpha, xrwrap_uv, xrwrap_xv
+from .data import (
+    DataCentralMoments,
+    DataCentralMomentsVals,
+    factory_data_values,
+)
+
+# expose some data/models
+from .models import (
+    Derivatives,
+    ExtrapModel,
+    ExtrapWeightedModel,
+    InterpModel,
+    InterpModelPiecewise,
+    MBARModel,
+    PerturbModel,
+    StateCollection,
+)
+
+__version__: str
+
+__all__ = [
+    "DataCentralMoments",
+    "DataCentralMomentsVals",
+    "Derivatives",
+    "ExtrapModel",
+    "ExtrapWeightedModel",
+    "InterpModel",
+    "InterpModelPiecewise",
+    "MBARModel",
+    "PerturbModel",
+    "StateCollection",
+    "__version__",
+    "beta",
+    "data",
+    "factory_data_values",
+    "idealgas",
+    "lnpi",
+    "models",
+    "volume",
+    "volume_idealgas",
+    "xrwrap_alpha",
+    "xrwrap_uv",
+    "xrwrap_xv",
+]


### PR DESCRIPTION
Use `__init__.pyi` with `lazy_loader`.  This prevents having to define import for type checking and run time seperately.