### PR TITLE
Improved SympyMeanFunction Fitting

### DIFF
--- a/src/thermoextrap/gpr_active/active_utils.py
+++ b/src/thermoextrap/gpr_active/active_utils.py
@@ -868,7 +868,7 @@ def train_GPR(
     """
     optim = gpflow.optimizers.Scipy()
     loss_info = optim.minimize(
-        gpr.training_loss, gpr.trainable_variables, method="L-BFGS-B", compile=False
+        gpr.training_loss, gpr.trainable_variables, method="SLSQP", compile=False
     )
 
     # If provided with starting parameters, also do optimization starting with them
@@ -883,7 +883,7 @@ def train_GPR(
 
         # Perform optimization starting with provided values
         loss_info_new = optim.minimize(
-            gpr.training_loss, gpr.trainable_variables, method="L-BFGS-B", compile=False
+            gpr.training_loss, gpr.trainable_variables, method="SLSQP", compile=False
         )
 
         # Make sure one or both losses are not NaN

--- a/src/thermoextrap/gpr_active/gp_models.py
+++ b/src/thermoextrap/gpr_active/gp_models.py
@@ -1313,6 +1313,12 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
         dictionary specifying starting parameter values for the mean function;
         in other words, these values will be substituted into the sympy
         expression to start with
+    x_dim : int, default 1
+        dimension of the input (x)
+    do_fit : bool, default True
+        whether or not to fit on data before training GP model
+    constrain_params : bool, default True
+        whether or not to constrain parameters when training GP model
     """
 
     def __init__(  # noqa: C901
@@ -1322,6 +1328,8 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
         y_data: NDArrayAny,
         params: OptionalKwsAny | None = None,
         x_dim: int = 1,
+        do_fit: bool = True,
+        constrain_params: bool = True,
     ) -> None:
         super().__init__()
         # Set dimensions of y data and x data
@@ -1333,7 +1341,7 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
         x_syms = []
         param_syms = []
         for s in expr.free_symbols:
-            if s.name.casefold() == "x":  # pyright: ignore[reportAttributeAccessIssue]
+            if "x" in s.name.casefold():  # pyright: ignore[reportAttributeAccessIssue]
                 x_syms.append(s)
             else:
                 param_syms.append(s)
@@ -1344,7 +1352,7 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
         self.param_syms = param_syms
 
         # Make sure that parameters here match those in params, if it's provided
-        if params:
+        if bool(params):
             if [s.name for s in self.param_syms].sort() != list(params.keys()).sort():
                 raise ValueError("Symbol names in expr must match keys in " + "params!")
             # If they are the same, obtain parameter values from params dictionary
@@ -1357,58 +1365,72 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
             for s in self.param_syms:
                 setattr(self, s.name, 1.0)
 
-        # Create function at zeroth order
-        mean_func = lambdify_with_defaults(
-            (*self.x_syms, *self.param_syms), self.expr, modules="numpy"
-        )
-        # And also wrap derivatives w.r.t. parameters for Jacobian
-        deriv_funcs = []
-        for p_sym in self.param_syms:
-            this_jac = sp.diff(self.expr, p_sym, 1)
-            deriv_funcs.append(
-                lambdify_with_defaults(
-                    (*self.x_syms, *self.param_syms), this_jac, modules="numpy"
-                )
+        if do_fit:
+            # Create function at zeroth order
+            mean_func = lambdify_with_defaults(
+                (*self.x_syms, *self.param_syms), self.expr, modules="numpy"
             )
+            # And also wrap derivatives w.r.t. parameters for Jacobian
+            deriv_funcs = []
+            for p_sym in self.param_syms:
+                this_jac = sp.diff(self.expr, p_sym, 1)
+                deriv_funcs.append(
+                    lambdify_with_defaults(
+                        (*self.x_syms, *self.param_syms), this_jac, modules="numpy"
+                    )
+                )
 
-        # Create loss function
-        def loss_func(params: Iterable[Any]) -> float:
-            return float(
-                np.sum(
+            # Create loss function
+            def loss_func(params: Iterable[Any]) -> float:
+                return np.sum(
                     (
                         mean_func(*np.split(x_data, self.x_dim, axis=-1), *params)
                         - y_data
                     )
                     ** 2
                 )
+
+            # And create Jacobian function
+            def jac_func(params: Iterable[Any]) -> NDArrayAny:
+                prefac = 2.0 * (mean_func(x_data, *params) - y_data)
+                jac = [
+                    np.sum(
+                        prefac * deriv(*np.split(x_data, self.x_dim, axis=-1), *params)
+                    )
+                    for deriv in deriv_funcs
+                ]
+                return np.array(jac)
+
+            # Perform optimization with scipy
+            opt = optimize.minimize(
+                loss_func,
+                np.array([getattr(self, s.name) for s in self.param_syms]),
+                method="L-BFGS-B",
+                jac=jac_func,
             )
+            logging.info("optimization opt: %s", opt)
 
-        # And create Jacobian function
-        def jac_func(params: Iterable[Any]) -> NDArrayAny:
-            prefac = 2.0 * (mean_func(x_data, *params) - y_data)
-            jac = [
-                np.sum(prefac * deriv(*np.split(x_data, self.x_dim, axis=-1), *params))
-                for deriv in deriv_funcs
-            ]
-            return np.array(jac)
+            # Set parameters based on optimization
+            for i, s in enumerate(self.param_syms):
+                setattr(
+                    self,
+                    s.name,
+                    gpflow.Parameter(opt.x[i], trainable=(not constrain_params)),
+                )
 
-        # Perform optimization with scipy
-        opt = optimize.minimize(
-            loss_func,
-            np.array([getattr(self, s.name) for s in self.param_syms]),
-            method="L-BFGS-B",
-            jac=jac_func,
-        )
-        logger.info("optimization opt: %s", opt)
-
-        # Set parameters based on optimization
-        for i, s in enumerate(self.param_syms):
-            setattr(self, s.name, opt.x[i])
+        else:
+            for s in self.param_syms:
+                this_val = getattr(self, s.name)
+                setattr(
+                    self,
+                    s.name,
+                    gpflow.Parameter(this_val, trainable=(not constrain_params)),
+                )
 
     def __call__(self, X: TensorType) -> tf.Tensor:
         """Closely follows K_diag from DerivativeKernel."""
         x_vals = X[:, : self.x_dim]
-        d_vals = X[:, self.x_dim :]
+        d_vals = tf.cast(X[:, self.x_dim :], tf.int32)
         unique_d = tf.raw_ops.UniqueV2(x=d_vals, axis=[0])[0]
         unique_d = tf.cast(unique_d, tf.int32)
         f_list = []


### PR DESCRIPTION
Added more flexibility for fitting parameters for SympyMeanFunction. Can choose whether fitting is done or not, and can also choose whether parameters are constrained during GPR optimization or not.  If fitting is done, it will only fit the mean function to zeroth-order data during __init__, before use in the GPR model.   If constrained_parameters is set to False, all parameters in the mean function will be optimized simultaneously with the GPR model.

Also switched optimizer method to SLSQP, which seems more stable and sometimes faster.  In general, the optimization procedure should be investigated in more detail, but this is a minor step in the right direction.