### PR TITLE
chore(bump): bump thermoextrap from 1.0.0 to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,39 @@
 
 Changelog for `thermoextrap`
 
+## 1.1.0
+
+Released on 2026-03-18.
+
+### Enhancements
+
+- feat(SympyMeanFuction): Add more flexibility in fitting process ([#25](https://github.com/usnistgov/thermoextrap/pull/25))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## v1.0.0 — 2025-09-29
 
 ### Removed
 
 - Removed `DataValues` and `DataValuesCentral` classes. Addition of
-  `resample_values` option to `DataCentralMomentsVals`, and addition of
-  `Dataset` support from `cmomy` package, made these classes redundant.
+`resample_values` option to `DataCentralMomentsVals`, and addition of
+`Dataset` support from `cmomy` package, made these classes redundant.
 
 ### Added
 
 - Added type annotations/checking. The core functionality is fully covered. GPR
-  modules are mostly covered (there are still so `Any` objects about). This
-  caught several edge case bugs.
-
+modules are mostly covered (there are still so `Any` objects about). This
+caught several edge case bugs.
 - Added `resample_values` option to `DataCentralMomentsVals` class. This allows
-  resampling on `uv` and `xv` instead of resampling during construction of
-  `dxduave`. Used in `PerturbModel`, etc.
+resampling on `uv` and `xv` instead of resampling during construction of
+`dxduave`. Used in `PerturbModel`, etc.
 
 ### Changed
 
 - Moved thermoextrap.legacy submodule to tests/legacy, as this module is used
-  solely for regression testing.
+solely for regression testing.
 
 ## v0.6.0 — 2025-02-18
 
@@ -34,7 +45,7 @@ Changelog for `thermoextrap`
 
 - Project now setup to use [uv](https://github.com/astral-sh/uv) with lock file.
 - Updated code to use latest version of
-  [cmomy](https://github.com/usnistgov/cmomy)
+[cmomy](https://github.com/usnistgov/cmomy)
 - Initial work for adding typing to code.
 
 ## v0.5.0 — 2024-03-15
@@ -50,33 +61,31 @@ Changelog for `thermoextrap`
 - Testing around basic multiD input GPRs
 - Updated `make_rbf_expr` in `active_utils` (old 1D in `make_rbf_expr_old`)
 - Updated `DerivativeKernel`, `HetGaussianDeriv`, `HeteroscedasticGPR` in
-  `gpr_models`
+`gpr_models`
 
 ### Changed
 
 - Updates to match with newer versions of GPflow
 - `HetGaussianDeriv` likelihood now accepts `X` (input data) argument for all
-  methods
+methods
 - `HetGaussianDeriv` init now takes `obs_dims` argument instead of `d_order`
 - `build_scaled_cov_mat` method now takes `X`, which includes derivative orders
 - all mean functions inherit from gpflow.functions.MeanFunction (same behavior)
-
 - Changed structure of the repo to better support some third party tools.
 - Moved nox environments from `.nox` to `.nox/{project-name}/envs`. This fixes
-  issues with ipykernel giving odd names for locally installed environments.
+issues with ipykernel giving odd names for locally installed environments.
 - Moved repo specific dot files to the `config` directory (e.g.,
-  `.noxconfig.toml` to `config/userconfig.toml`). This cleans up the top level
-  of the repo.
+`.noxconfig.toml` to `config/userconfig.toml`). This cleans up the top level
+of the repo.
 - added some support for using `nbqa` to run mypy/pyright on notebooks.
 - Added ability to bootstrap development environment using pipx. This should
-  simplify initial setup. See Contributing for more info.
+simplify initial setup. See Contributing for more info.
 
 ## v0.4.0 — 2023-06-15
 
 ### Added
 
 - Package now available on conda-forge
-
 - Now support python3.11
 - Bumped pymbar version to pymbar>=4.0
 
@@ -94,10 +103,9 @@ Changelog for `thermoextrap`
 
 - New linters via pre-commit
 - Development env now handled by tox
-
 - Moved `models, data, idealgas` from `thermoextrap.core` to `thermoextrap`.
-  These were imported at top level anyway. This fixes issues with doing things
-  like `from thermoextrap.data import ...`, etc.
+These were imported at top level anyway. This fixes issues with doing things
+like `from thermoextrap.data import ...`, etc.
 - Moved `core._docstrings_` to `docstrings`.
 - Now using `cmomy.docstrings` instead of repeating them here.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Released on 2026-03-18.
 
 ### Enhancements
 
-- feat(SympyMeanFuction): Add more flexibility in fitting process ([#25](https://github.com/usnistgov/thermoextrap/pull/25))
+- feat(SympyMeanFunction): Add more flexibility in fitting process ([#25](https://github.com/usnistgov/thermoextrap/pull/25))
 
 ### Contributors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "thermoextrap"
-version = "1.0.0"
+version = "1.1.0"
 description = "Thermodynamic extrapolation"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,7 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-11T00:57:47.13607Z"
+exclude-newer = "2026-03-11T01:12:02.911334573Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -5369,7 +5369,7 @@ wheels = [
 
 [[package]]
 name = "thermoextrap"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs", marker = "python_full_version < '3.13' or sys_platform == 'linux'" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)