### PR TITLE
fix: Bug fix in SympyMeanFunc

### DIFF
--- a/src/thermoextrap/gpr_active/active_utils.py
+++ b/src/thermoextrap/gpr_active/active_utils.py
@@ -841,6 +841,8 @@ def train_GPR(
     gpr: Any,
     record_loss: bool = False,
     start_params: Mapping[int, Any] | Sequence[Any] | None = None,
+    minimize_method: str = "SLSQP",
+    **scipy_kwargs: Any,
 ) -> OptimizeResult | None:
     """
     Trains a given gpr model for n_opt steps.
@@ -861,10 +863,28 @@ def train_GPR(
         parameters set to start_params; the optimization result with the lowest
         loss function value is selected and the GPR parameters are set to those
         values
+    minimize_method : str, default="SLSQP"
+        ``method`` argument to :func:`~scipy.optimize.minimize`.
+    **scipy_kwargs
+        Extra keyword arguments to :func:`~scipy.optimize.minimize`.
+
+    Returns
+    -------
+    :class:`~scipy.optimize.OptimizeResult`, optional
+
+    See Also
+    --------
+    scipy.optimize.minimize
+    gpflow.optimizers.Scipy
+    gpflow.optimizers.Scipy.minimize
     """
     optim = gpflow.optimizers.Scipy()
     loss_info = optim.minimize(
-        gpr.training_loss, gpr.trainable_variables, method="SLSQP", compile=False
+        gpr.training_loss,
+        gpr.trainable_variables,
+        method=minimize_method,
+        compile=False,
+        **scipy_kwargs,
     )
 
     # If provided with starting parameters, also do optimization starting with them
@@ -881,11 +901,11 @@ def train_GPR(
 
         # Perform optimization starting with provided values
         loss_info_new = optim.minimize(
-            # gpr.training_loss, gpr.trainable_variables, method="SLSQP", compile=False
             gpr.training_loss,
             gpr.trainable_variables,
-            method="SLSQP",
+            method=minimize_method,
             compile=False,
+            **scipy_kwargs,
         )
 
         # Make sure one or both losses are not NaN

--- a/src/thermoextrap/gpr_active/gp_models.py
+++ b/src/thermoextrap/gpr_active/gp_models.py
@@ -1355,6 +1355,14 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
         whether or not to fit on data before training GP model
     constrain_params : bool, default True
         whether or not to constrain parameters when training GP model
+    minimize_method : str, default="SLSQP"
+        ``method`` argument to :func:`~scipy.optimize.minimize`.
+    **scipy_kwargs
+        Extra keyword arguments to :func:`~scipy.optimize.minimize`.
+
+    See Also
+    --------
+    scipy.optimize.minimize
     """
 
     def __init__(  # noqa: C901, PLR0912
@@ -1365,6 +1373,8 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
         params: OptionalKwsAny | None = None,
         do_fit: bool = True,
         constrain_params: bool = True,
+        minimize_method: str = "SLSQP",
+        **scipy_kwargs: Any,
     ) -> None:
         super().__init__()
         # Set dimensions of y data and x data
@@ -1439,11 +1449,12 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
                 return np.array(jac)
 
             # Perform optimization with scipy
-            opt = optimize.minimize(
+            opt = optimize.minimize(  # type: ignore[call-overload]
                 loss_func,
                 np.array([getattr(self, s.name) for s in self.param_syms]),
-                method="SLSQP",
                 jac=jac_func,
+                method=minimize_method,  # pyright: ignore[reportCallIssue, reportArgumentType]
+                **scipy_kwargs,
             )
             logger.info("optimization opt: %s", opt)
 

--- a/src/thermoextrap/gpr_active/gp_models.py
+++ b/src/thermoextrap/gpr_active/gp_models.py
@@ -1351,8 +1351,6 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
         dictionary specifying starting parameter values for the mean function;
         in other words, these values will be substituted into the sympy
         expression to start with
-    x_dim : int, default 1
-        dimension of the input (x)
     do_fit : bool, default True
         whether or not to fit on data before training GP model
     constrain_params : bool, default True
@@ -1365,7 +1363,6 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
         x_data: NDArrayAny,
         y_data: NDArrayAny,
         params: OptionalKwsAny | None = None,
-        x_dim: int = 1,
         do_fit: bool = True,
         constrain_params: bool = True,
     ) -> None:
@@ -1430,7 +1427,9 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
 
             # And create Jacobian function
             def jac_func(params: Iterable[Any]) -> NDArrayAny:
-                prefac = 2.0 * (mean_func(x_data, *params) - y_data)
+                prefac = 2.0 * (
+                    mean_func(*np.split(x_data, self.x_dim, axis=-1), *params) - y_data
+                )
                 jac = [
                     np.sum(
                         prefac * deriv(*np.split(x_data, self.x_dim, axis=-1), *params)
@@ -1443,7 +1442,7 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
             opt = optimize.minimize(
                 loss_func,
                 np.array([getattr(self, s.name) for s in self.param_syms]),
-                method="L-BFGS-B",
+                method="SLSQP",
                 jac=jac_func,
             )
             logger.info("optimization opt: %s", opt)
@@ -1492,6 +1491,7 @@ class SympyMeanFunc(gpflow.functions.MeanFunction):
                     *tf.split(tf.gather_nd(x_vals, this_inds), self.x_dim, axis=-1),
                     *[getattr(self, s.name) for s in self.param_syms],
                 )
+                * tf.ones(tf.shape(this_inds), dtype=x_vals.dtype)
             )
             inds_list.append(this_inds)
 

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -418,7 +418,11 @@ def test_sympy_mean_func() -> None:
 
     # Create our mean function to test
     check_sym = SympyMeanFunc(
-        sig_expr, x_check[: len(x_vals), :1], y_check[: len(x_vals)], params=params
+        sig_expr,
+        x_check[: len(x_vals), :1],
+        y_check[: len(x_vals)],
+        params=params,
+        options={"ftol": 1e-12},
     )
 
     # Check that expression matches input


### PR DESCRIPTION
This is a quick fix that should not break anything else.  SympyMeanFunc was not working when the derivative ended up being a constant or zero.  In that case, the inputs are not used and so the output does not take on the correct shape.  There may be a better fix through sympy's lambdify interface, but I didn't see anything obvious.  May want to add a test for this, like a polynomial test case of similar structure to test_sympy_mean_func() in test_gps.py, but leaving for now.  Seems like probably a pretty fringe case and not even sure will be relevant in the future.

Note that this could also impact the DerivativeKernel class, but if that error appears there, the chosen kernel is probably not a valid choice (i.e., it will have a constant or zero derivative at a certain order, meaning it is not differentiable up to the required order).  I'm not sure why we would ever need such behavior, but in case we do I'm documenting the fix here.