### PR TITLE
chore(bump): bump thermoextrap from 1.1.0 to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 Changelog for `thermoextrap`
 
+## 1.1.1
+
+Released on 2026-05-05.
+
+### Bug fixes
+
+- fix: Bug fix in SympyMeanFunc ([#96](https://github.com/usnistgov/thermoextrap/pull/96))
+
+### Contributors
+
+- [@JIMonroe](https://github.com/JIMonroe)
+
 ## 1.1.0
 
 Released on 2026-03-18.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "thermoextrap"
-version = "1.1.0"
+version = "1.1.1"
 description = "Thermodynamic extrapolation"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -5392,7 +5392,7 @@ wheels = [
 
 [[package]]
 name = "thermoextrap"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs", marker = "python_full_version < '3.13' or sys_platform == 'linux'" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)