### PR TITLE
chore(bump): bump thermoextrap from 1.2.0 to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 Changelog for `thermoextrap`
 
+## 1.2.1
+
+Released on 2026-07-28.
+
+### Bug fixes
+
+- fix: Modifying kernel for large memory situations ([#200](https://github.com/usnistgov/thermoextrap/pull/200))
+
+### Contributors
+
+- [@JIMonroe](https://github.com/JIMonroe)
+
 ## 1.2.0
 
 Released on 2026-05-21.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "thermoextrap"
-version = "1.2.0"
+version = "1.2.1"
 description = "Thermodynamic extrapolation"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -5853,7 +5853,7 @@ wheels = [
 
 [[package]]
 name = "thermoextrap"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)